### PR TITLE
Remove dependency for globally installed Gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
 #### 1.1 Pre-Requirements
 
 ```
-$ sudo npm install -g gulpjs/gulp-cli#4.0
-```
-
-```
 $ npm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ $ npm install
 use this command to list all available tasks
 
 ```
-$ gulp --tasks
+$ npm start -- --tasks
 ```
 
 ##### 1.3.1 Main tasks
 
-use `gulp build` for production or `gulp dev` for development
+use `npm start build` for production or `npm start dev` for development

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Frontend Starter",
   "license": "GPL-3.0",
   "scripts": {
-    "start": "gulp dev",
+    "start": "npm run gulp",
+    "gulp": "gulp",
     "test": "echo \"ERR: No test specified!\" && exit 1"
   },
   "author": "Project A Ventures",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Frontend Starter",
   "license": "GPL-3.0",
   "scripts": {
-    "start": "npm run gulp",
+    "start": "npm run gulp --",
     "gulp": "gulp",
     "test": "echo \"ERR: No test specified!\" && exit 1"
   },


### PR DESCRIPTION
I would really prefer to have just a local dependency for Gulp. This way there are no conflicts if one has to work on a project still relying on Gulp 3.x.